### PR TITLE
[FIX] move's create should be overrided properly to avoid flush_recordset

### DIFF
--- a/account_banking_mandate/models/account_move.py
+++ b/account_banking_mandate/models/account_move.py
@@ -20,8 +20,8 @@ class AccountMove(models.Model):
         related="payment_mode_id.payment_method_id.mandate_required", readonly=True
     )
 
-    @api.model
-    def create(self, vals):
+    @api.model_create_multi
+    def create(self, vals_list):
         """Fill the mandate_id from the partner if none is provided on
         creation, using same method as upstream."""
         onchanges = {
@@ -29,16 +29,17 @@ class AccountMove(models.Model):
             "_onchange_payment_mode_id": ["mandate_id"],
         }
         for onchange_method, changed_fields in list(onchanges.items()):
-            if any(f not in vals for f in changed_fields):
-                move = self.new(vals)
-                move = move.with_company(move.company_id.id)
-                getattr(move, onchange_method)()
-                for field in changed_fields:
-                    if field not in vals and move[field]:
-                        vals[field] = move._fields[field].convert_to_write(
-                            move[field], move
-                        )
-        return super().create(vals)
+            for vals in vals_list:
+                if any(f not in vals for f in changed_fields):
+                    move = self.new(vals)
+                    move = move.with_company(move.company_id.id)
+                    getattr(move, onchange_method)()
+                    for field in changed_fields:
+                        if field not in vals and move[field]:
+                            vals[field] = move._fields[field].convert_to_write(
+                                move[field], move
+                            )
+        return super().create(vals_list)
 
     def set_mandate(self):
         if self.payment_mode_id.payment_method_id.mandate_required:


### PR DESCRIPTION
I got an issue when migrating the module `account_banking_sepa_credit_transfer`
The test cases will fail two modules `account_banking_mandate` and `account_banking_sepa_credit_transfer` installed

## Cause

- Odoo just implemented an [update](https://github.com/odoo/odoo/commit/cb76725b071d8#diff-1e3bd6be3bfb83a37ec9fb800ce8b1c95afe0be90ff792874ae7299c320a2f6eR2257) where the cache is reset in `write`